### PR TITLE
Tweaks to examples and cleanup a few things

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
 # Fixpoint Python SDK
+
 The `FixpointClient` wraps the OpenAI API Client. You can call it just like OpenAI API Client. The sdk will intercept calls to certain OpenAI APIs, record input / outputs and forward that information to Fixpoint's api server.
 
 ## Usage
+
 To use the sdk make sure that you have the following variables set in your environment: `FIXPOINT_API_KEY` and `OPENAI_API_KEY`.
 
 ## Virtual Env
+
 To create a virtual environment called `venv` from your terminal run `python3 -m venv venv`.
 
 ### Activate
+
 `source venv/bin/activate`
 
 ### Install packages
+
 To install packages from `requirements.txt` in your virtual environment using `pip` run: `pip install -r requirements.txt`
 
 ### Deactivate
+
 `deactivate`
 
 ## Examples
+
 You can find examples of how to use the API in `examples`.

--- a/src/client.py
+++ b/src/client.py
@@ -1,7 +1,8 @@
 import json
 from openai import OpenAI
-from lib.env import get_fixpoint_api_key
-from lib.requests import create_attribute, create_openai_input_log, create_openai_output_log, create_user_feedback
+from .lib.env import get_fixpoint_api_key
+from .lib.requests import create_attribute, create_openai_input_log, create_openai_output_log, create_user_feedback
+from .lib.debugging import dprint
 
 class FixpointClient:
   def __init__(self, *args, **kwargs):
@@ -18,7 +19,6 @@ class FixpointClient:
       self.attributes = self._Attributes()
 
     class _UserFeedback:
-      
       def create(self, request):
         create_user_feedback(request)
 
@@ -43,17 +43,17 @@ class FixpointClient:
       # Send HTTP request before calling create
       input_resp = create_openai_input_log(reqCopy['model_name'], reqCopy, trace_id=trace_id)
       input_log_results = input_resp.json()
-      print('Created an input log: {}'.format(input_log_results['name']))
+      dprint('Created an input log: {}'.format(input_log_results['name']))
 
       # Make create call to OPEN AI
       openai_response = self.client.chat.completions.create(*args, **kwargs)
       openai_results = json.loads(openai_response.json())
-      print('Received an openai response: {}'.format(openai_results.get('id')))
+      dprint('Received an openai response: {}'.format(openai_results.get('id')))
 
       # Send HTTP request after calling create
       output_resp = create_openai_output_log(reqCopy['model_name'], input_log_results, openai_results, trace_id=trace_id)
       output_log_results = output_resp.json()
-      print('Created an output log: {}'.format(output_log_results['name']))
+      dprint('Created an output log: {}'.format(output_log_results['name']))
 
       return openai_response, input_log_results, output_log_results
 

--- a/src/lib/debugging.py
+++ b/src/lib/debugging.py
@@ -1,0 +1,7 @@
+import os
+
+def dprint(*args, **kwargs):
+    debugmode = os.environ.get('DEBUG', 'off').lower()
+    if debugmode not in ['on', 'true', '1']:
+        return
+    print(*args, **kwargs) 

--- a/src/lib/requests.py
+++ b/src/lib/requests.py
@@ -1,6 +1,6 @@
 import enum
 import requests
-from lib.env import get_fixpoint_api_key
+from .env import get_fixpoint_api_key
 
 BASE_URL = "https://api.fixpoint.co"
 


### PR DESCRIPTION
Make some minor high level adjustments:

1. all imports within the package are relative, for better portability
2. replace `print` with `dprint` that only prints if `DEBUG` environment variable is one of "true", "on", or "1"
3. Add some more comments to the examples file