### PR TITLE
Refactor SDK to pass in environment and raise HTTP errors

### DIFF
--- a/src/fixpoint_sdk/client.py
+++ b/src/fixpoint_sdk/client.py
@@ -35,7 +35,7 @@ class FixpointClient:
         self._requester = requester
 
       def create(self, request):
-        self._requester.create_user_feedback(request)
+        return self._requester.create_user_feedback(request)
 
     class _Attributes:
       def __init__(self, requester: Requester):

--- a/src/fixpoint_sdk/client.py
+++ b/src/fixpoint_sdk/client.py
@@ -1,34 +1,53 @@
 import json
+import typing
 from openai import OpenAI
 from .lib.env import get_fixpoint_api_key
-from .lib.requests import create_attribute, create_openai_input_log, create_openai_output_log, create_user_feedback
+from .lib.requests import Requester
 from .lib.debugging import dprint
 
 class FixpointClient:
-  def __init__(self, *args, **kwargs):
+  def __init__(
+    self,
+    fixpoint_api_key: typing.Optional[str],
+    openai_api_key: typing.Optional[str],
+    api_base_url: typing.Optional[str],
+    *args,
+    **kwargs
+  ):
     # Check that the environment variable FIXPOINT_API_KEY is set
-    get_fixpoint_api_key()
+    _api_key = get_fixpoint_api_key(fixpoint_api_key)
 
+    self._api_key = _api_key
+    self._requester = Requester(self._api_key, api_base_url)
+    if openai_api_key:
+      kwargs = dict(kwargs, api_key=openai_api_key)
     self.client = OpenAI(*args, **kwargs)
-    self.chat = self._Chat(self.client)
-    self.fixpoint = self._Fixpoint()
+    self.chat = self._Chat(self._requester, self.client)
+    self.fixpoint = self._Fixpoint(self._requester)
 
   class _Fixpoint:
-    def __init__(self):
-      self.user_feedback = self._UserFeedback()
-      self.attributes = self._Attributes()
+    def __init__(self, requester: Requester):
+      self.user_feedback = self._UserFeedback(requester)
+      self.attributes = self._Attributes(requester)
 
     class _UserFeedback:
+      def __init__(self, requester: Requester):
+        self._requester = requester
+
       def create(self, request):
-        create_user_feedback(request)
+        self._requester.create_user_feedback(request)
 
     class _Attributes:
+      def __init__(self, requester: Requester):
+        self._requester = requester
+
       def create(self, request):
-        create_attribute(request)
+        self._requester.create_attribute(request)
 
   class _Completions:
-    def __init__(self, client):
+    def __init__(self, requester: Requester, client: OpenAI):
       self.client = client
+      self._requester = requester
 
     def create(self, *args, **kwargs):
       # Extract trace_id from kwargs, if it exists, otherwise set it to None
@@ -41,7 +60,9 @@ class FixpointClient:
       reqCopy['model_name'] = reqCopy.pop('model')
 
       # Send HTTP request before calling create
-      input_resp = create_openai_input_log(reqCopy['model_name'], reqCopy, trace_id=trace_id)
+      input_resp = self._requester.create_openai_input_log(
+        reqCopy['model_name'], reqCopy, trace_id=trace_id
+      )
       input_log_results = input_resp.json()
       dprint('Created an input log: {}'.format(input_log_results['name']))
 
@@ -51,12 +72,14 @@ class FixpointClient:
       dprint('Received an openai response: {}'.format(openai_results.get('id')))
 
       # Send HTTP request after calling create
-      output_resp = create_openai_output_log(reqCopy['model_name'], input_log_results, openai_results, trace_id=trace_id)
+      output_resp = self._requester.create_openai_output_log(
+        reqCopy['model_name'], input_log_results, openai_results, trace_id=trace_id
+      )
       output_log_results = output_resp.json()
       dprint('Created an output log: {}'.format(output_log_results['name']))
 
       return openai_response, input_log_results, output_log_results
 
   class _Chat:
-    def __init__(self, client):
-      self.completions = FixpointClient._Completions(client)
+    def __init__(self, requester: Requester, client: OpenAI):
+      self.completions = FixpointClient._Completions(requester, client)

--- a/src/fixpoint_sdk/lib/env.py
+++ b/src/fixpoint_sdk/lib/env.py
@@ -1,9 +1,19 @@
 import os
+import typing
 import sys
 
-def get_fixpoint_api_key():
+from .exc import InitException
+
+def get_fixpoint_api_key(api_key: typing.Optional[str]):
+  if api_key:
+    return api_key
   if 'FIXPOINT_API_KEY' not in os.environ:
-    print("FIXPOINT_API_KEY env variable not set. Exiting...")
-    sys.exit(1)
+    print("FIXPOINT_API_KEY env variable not set.")
+    raise InitException("Fixpoint API key not set")
   else:
-    return os.environ['FIXPOINT_API_KEY']
+    key = os.environ['FIXPOINT_API_KEY']
+    if not key:
+      print("FIXPOINT_API_KEY env variable is empty.")
+      raise InitException("Fixpoint API key is empty")
+    return key
+ 

--- a/src/fixpoint_sdk/lib/exc.py
+++ b/src/fixpoint_sdk/lib/exc.py
@@ -1,0 +1,2 @@
+class InitException(Exception):
+    pass

--- a/src/fixpoint_sdk/lib/requests.py
+++ b/src/fixpoint_sdk/lib/requests.py
@@ -1,6 +1,6 @@
 import enum
 import requests
-from .env import get_fixpoint_api_key
+import typing
 
 BASE_URL = "https://api.fixpoint.co"
 
@@ -14,108 +14,121 @@ class OriginType(enum.Enum):
   ORIGIN_USER_FEEDBACK = 1
   ORIGIN_ADMIN = 2
 
-def create_openai_input_log(model_name, request, trace_id=None):
-  url = '{}/v1/openai_chats/{model_name}/input_logs'.format(BASE_URL, model_name=model_name)
+class Requester:
+  api_key: str
+  base_url: str
 
-  requestObj = {
-    'model_name': model_name,
-    'messages': request['messages'],
-  }
+  def __init__(self, api_key: str, base_url: typing.Optional[str]):
+    self.api_key = api_key
+    if not base_url:
+      self.base_url = BASE_URL
+    else:
+      self.base_url = base_url
 
-  if 'user' in request:
-    requestObj['user_id'] = request['user']
+  def create_openai_input_log(self, model_name, request, trace_id=None):
+    url = '{}/v1/openai_chats/{model_name}/input_logs'.format(self.base_url, model_name=model_name)
 
-  if 'temperature' in request:
-    requestObj['temperature'] = request['temperature']
+    requestObj = {
+      'model_name': model_name,
+      'messages': request['messages'],
+    }
 
-  # If trace_id exists, add it to the requestObj
-  if trace_id:
-    requestObj['trace_id'] = trace_id
+    if 'user' in request:
+      requestObj['user_id'] = request['user']
 
-  return post_to_fixpoint(url, requestObj)
+    if 'temperature' in request:
+      requestObj['temperature'] = request['temperature']
 
-def create_openai_output_log(model_name, input_log_results, open_ai_response, trace_id=None):
+    # If trace_id exists, add it to the requestObj
+    if trace_id:
+      requestObj['trace_id'] = trace_id
 
-  url = '{}/v1/openai_chats/{model_name}/output_logs'.format(BASE_URL, model_name=model_name)
+    return self.post_to_fixpoint(url, requestObj)
 
-  # If input_log_results doesn't have id then error
-  if 'name' not in input_log_results:
-    raise ValueError('input_log_results must have a name')
 
-  # If open_ai_response doesn't have id then error
-  if 'id' not in open_ai_response:
-    raise ValueError('open_ai_response must have an id')
+  def create_openai_output_log(self, model_name, input_log_results, open_ai_response, trace_id=None):
+    url = '{}/v1/openai_chats/{model_name}/output_logs'.format(self.base_url, model_name=model_name)
 
-  choices = []
-  for choice in open_ai_response['choices']:
-    choices.append({
-      "index": str(choice['index']),
-      "message": choice['message'],
-      "finish_reason": choice['finish_reason'],
-    })
+    # If input_log_results doesn't have id then error
+    if 'name' not in input_log_results:
+      raise ValueError('input_log_results must have a name')
 
-  requestObj = {
-    'input_name': input_log_results['name'],
-    'openai_id': open_ai_response['id'],
-    'model_name': model_name,
-    'choices': choices,
-    'usage': open_ai_response['usage'],
-  }
+    # If open_ai_response doesn't have id then error
+    if 'id' not in open_ai_response:
+      raise ValueError('open_ai_response must have an id')
 
-  # If trace_id exists, add it to the requestObj
-  if trace_id:
-    requestObj['trace_id'] = trace_id
+    choices = []
+    for choice in open_ai_response['choices']:
+      choices.append({
+        "index": str(choice['index']),
+        "message": choice['message'],
+        "finish_reason": choice['finish_reason'],
+      })
 
-  return post_to_fixpoint(url, requestObj)
+    requestObj = {
+      'input_name': input_log_results['name'],
+      'openai_id': open_ai_response['id'],
+      'model_name': model_name,
+      'choices': choices,
+      'usage': open_ai_response['usage'],
+    }
 
-def create_user_feedback(request):
-  url = '{}/v1/likes'.format(BASE_URL)
+    # If trace_id exists, add it to the requestObj
+    if trace_id:
+      requestObj['trace_id'] = trace_id
 
-  if 'likes' not in request:
-    raise ValueError('request must have a likes')
-  
-  if not isinstance(request['likes'], list):
-    raise ValueError('request.likes must be a list')
-  
-  for like in request['likes']:
-    if 'log_name' not in like:
-      raise ValueError('request must have a log_name')
+    return self.post_to_fixpoint(url, requestObj)
 
-    if 'thumbs_reaction' not in like:
-      raise ValueError('request must have a thumbs_reaction')
-    like['thumbs_reaction'] = like['thumbs_reaction'].value
+
+  def create_user_feedback(self, request):
+    url = '{}/v1/likes'.format(self.base_url)
+
+    if 'likes' not in request:
+      raise ValueError('request must have a likes')
     
-    if 'user_id' not in like:
-      raise ValueError('request must have a user_id')
+    if not isinstance(request['likes'], list):
+      raise ValueError('request.likes must be a list')
+    
+    for like in request['likes']:
+      if 'log_name' not in like:
+        raise ValueError('request must have a log_name')
 
-    like['origin'] = OriginType.ORIGIN_USER_FEEDBACK.value
+      if 'thumbs_reaction' not in like:
+        raise ValueError('request must have a thumbs_reaction')
+      like['thumbs_reaction'] = like['thumbs_reaction'].value
+      
+      if 'user_id' not in like:
+        raise ValueError('request must have a user_id')
 
-  return post_to_fixpoint(url, request)
+      like['origin'] = OriginType.ORIGIN_USER_FEEDBACK.value
 
-def create_attribute(request):
-  url = '{}/v1/attributes'.format(BASE_URL)
+    return self.post_to_fixpoint(url, request)
 
-  if 'log_attribute' not in request:
-    raise ValueError('request must have a log_attribute')
-  
-  log_attribute = request['log_attribute']
 
-  if 'key' not in log_attribute:
-    raise ValueError('log_attribute must have a key')
-  
-  if 'value' not in log_attribute:
-    raise ValueError('log_attribute must have a value')
-  
-  if 'log_name' not in log_attribute:
-    raise ValueError('log_attribute must have a log_name')
-  
-  return post_to_fixpoint(url, request)
+  def create_attribute(self, request):
+    url = '{}/v1/attributes'.format(self.base_url)
 
-def post_to_fixpoint(url, reqOrRespObj):
-  apiKey = get_fixpoint_api_key()
-  headers = {
-    'Accept': 'application/json',
-    'Authorization': 'Bearer {}'.format(apiKey),
-  }
+    if 'log_attribute' not in request:
+      raise ValueError('request must have a log_attribute')
+    
+    log_attribute = request['log_attribute']
 
-  return requests.post(url, headers=headers, json=reqOrRespObj)
+    if 'key' not in log_attribute:
+      raise ValueError('log_attribute must have a key')
+    
+    if 'value' not in log_attribute:
+      raise ValueError('log_attribute must have a value')
+    
+    if 'log_name' not in log_attribute:
+      raise ValueError('log_attribute must have a log_name')
+    
+    return self.post_to_fixpoint(url, request)
+
+
+  def post_to_fixpoint(self, url, reqOrRespObj):
+    headers = {
+      'Accept': 'application/json',
+      'Authorization': 'Bearer {}'.format(self.api_key),
+    }
+
+    return requests.post(url, headers=headers, json=reqOrRespObj)

--- a/src/fixpoint_sdk/lib/requests.py
+++ b/src/fixpoint_sdk/lib/requests.py
@@ -131,4 +131,6 @@ class Requester:
       'Authorization': 'Bearer {}'.format(self.api_key),
     }
 
-    return requests.post(url, headers=headers, json=reqOrRespObj)
+    resp = requests.post(url, headers=headers, json=reqOrRespObj)
+    resp.raise_for_status()
+    return resp

--- a/src/fixpoint_sdk/lib/requests.py
+++ b/src/fixpoint_sdk/lib/requests.py
@@ -102,7 +102,8 @@ class Requester:
 
       like['origin'] = OriginType.ORIGIN_USER_FEEDBACK.value
 
-    return self.post_to_fixpoint(url, request)
+    resp = self.post_to_fixpoint(url, request)
+    return resp.json()
 
 
   def create_attribute(self, request):


### PR DESCRIPTION
Refactor the SDK so that the client can now pass in API keys and the base API URL. For requests, instead of having top-level functions we now have a `Requester` class that you can configure with the API keys and API base URL.

Also, change the HTTP requests to raise an error if we receive 400+ status code.