### PR TITLE
Allow a wider version range for OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,18 @@ To create a virtual environment called `venv` from your terminal run `python3 -m
 
 #### Install packages
 
-To install packages from `requirements.txt` in your virtual environment using
-`pip` run: `pip install -r requirements.txt`.
-
-If you want to install from the dependencies in `pyproject.toml` and not from
-the `requirement.txt`, you can run:
+To install the package locally for development:
 
 ```
-pip install .
-
-# or in "editable mode" so your install changes as you update the source code:
+# in "editable mode" so your install changes as you update the source code:
 pip install -e .
 
 # and to install dev dependencies
 pip install -e '.[dev]'
 ```
+
+In general, you should not install from the `requirements.txt` file, instead
+following the installation method suggested above.
 
 #### Deactivate
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fixpoint_sdk"
-version = "0.1.1"
+version = "0.1.2"
 
 authors = [
 { name="Jakub Cichon", email="jakub@fixpoint.co" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "openai>=1.12.0",
+  "openai>=1.6.1",
   "requests==2.31.0"
 ]
 


### PR DESCRIPTION
Allow a wider version range for the `openai` dependency, starting at `openai>=1.6.1`.

Update our README to not suggest installing from `requirements.txt`. For local development, users should install from `pyproject.toml`.

Increment the version to v0.1.2 for publishing.