### PR TITLE
Fix a bug when `stream` arg was not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ pip install -e .
 pip install -e '.[dev]'
 ```
 
+If you get an error like:
+
+> ERROR: File "setup.py" not found. Directory cannot be installed in editable mode: /home/dbmikus/workspace/github.com/gofixpoint/python-sdk
+> (A "pyproject.toml" file was found, but editable mode currently requires a setup.py based build.)
+
+Try upgrading pip and retrying:
+
+```
+pip install --upgrade pip
+pip install -e .
+```
+
+
 In general, you should not install from the `requirements.txt` file, instead
 following the installation method suggested above.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fixpoint_sdk"
-version = "0.2.0"
+version = "0.2.1"
 
 authors = [
 { name="Jakub Cichon", email="jakub@fixpoint.co" },

--- a/src/fixpoint_sdk/completions.py
+++ b/src/fixpoint_sdk/completions.py
@@ -190,7 +190,7 @@ class Completions:
         )
         dprint(f'Created an input log: {input_resp["name"]}')
 
-        stream = kwargs["stream"]
+        stream = kwargs.get("stream", False)
         # Make create call to OPEN AI
         openai_response = self.client.chat.completions.create(*args, **kwargs)
         if stream:


### PR DESCRIPTION
We had a bug because we were always expecting the `stream` kwarg to be set. Fix that, defaulting to `False` if unset.

Also, add some clarifying comments for installing in editable mode and update the package version to v0.2.1.