### PR TITLE
Log a warning when accessing output log early while streaming

### DIFF
--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -29,9 +29,15 @@ def main() -> None:
     output_log = resp.output_log
     assert output_log is None
     text_contents = []
+
+    # You can iterate via `resp.completions`, like below, or via `resp` directly like:
+    #
+    #     for chunk in resp:
+    #         ...
+    #
     # Pylint is getting this wrong
     # pylint: disable=not-an-iterable
-    for chunk in resp:
+    for chunk in resp.completions:
         content = chunk.choices[0].delta.content
         if content:
             text_contents.append(content)

--- a/src/fixpoint_sdk/__init__.py
+++ b/src/fixpoint_sdk/__init__.py
@@ -5,6 +5,7 @@ from .completions import FixpointChatCompletion, FixpointChatCompletionStream
 from . import types
 from .types import ThumbsReaction, ModeType
 from . import compat
+from .lib.logging import logger, LOGGER_NAME
 
 __all__ = [
     "FixpointClient",
@@ -14,4 +15,6 @@ __all__ = [
     "compat",
     "FixpointChatCompletion",
     "FixpointChatCompletionStream",
+    "logger",
+    "LOGGER_NAME",
 ]

--- a/src/fixpoint_sdk/lib/debugging.py
+++ b/src/fixpoint_sdk/lib/debugging.py
@@ -7,6 +7,8 @@ import typing
 from typing import Callable, TypeVar
 from typing_extensions import ParamSpec
 
+from .logging import logger
+
 
 def _is_debug_mode() -> bool:
     debugmode = os.environ.get("DEBUG", "off").lower()
@@ -17,7 +19,7 @@ def dprint(*args: typing.Any, **kwargs: typing.Any) -> None:
     """Prints only if debug mode is on."""
     if not _is_debug_mode():
         return
-    print(*args, **kwargs)
+    logger.debug(*args, **kwargs)
 
 
 P = ParamSpec("P")
@@ -53,7 +55,7 @@ class FnIO:
 
     def log(self) -> None:
         """Prints a text representation of the FnIO object."""
-        print(self.to_dict())
+        logger.info(self.to_dict())
 
 
 def debug_log_function_io(func: Callable[P, T]) -> Callable[P, T]:

--- a/src/fixpoint_sdk/lib/env.py
+++ b/src/fixpoint_sdk/lib/env.py
@@ -4,6 +4,7 @@ import os
 import typing
 
 from .exc import InitException
+from .logging import logger
 
 
 def get_fixpoint_api_key(api_key: typing.Optional[str]) -> str:
@@ -16,12 +17,12 @@ def get_fixpoint_api_key(api_key: typing.Optional[str]) -> str:
         return api_key
 
     if "FIXPOINT_API_KEY" not in os.environ:
-        print("FIXPOINT_API_KEY env variable not set.")
+        logger.error("FIXPOINT_API_KEY env variable not set.")
         raise InitException("Fixpoint API key not set")
 
     key = os.environ["FIXPOINT_API_KEY"]
     if not key:
-        print("FIXPOINT_API_KEY env variable is empty.")
+        logger.error("FIXPOINT_API_KEY env variable is empty.")
         raise InitException("Fixpoint API key is empty")
     return key
 
@@ -44,7 +45,7 @@ def _get_api_base_url(base_url: typing.Optional[str]) -> str:
     if _FIXPOINT_BASE_URL_ENV_KEY in os.environ:
         base_url = os.environ[_FIXPOINT_BASE_URL_ENV_KEY]
         if not base_url:
-            print(f"{_FIXPOINT_BASE_URL_ENV_KEY} env variable is empty.")
+            logger.error("%s env variable is empty.", _FIXPOINT_BASE_URL_ENV_KEY)
             raise InitException("Fixpoint API base URL is empty")
         return base_url
     return BASE_URL

--- a/src/fixpoint_sdk/lib/logging.py
+++ b/src/fixpoint_sdk/lib/logging.py
@@ -1,0 +1,7 @@
+"""Logging for the Fixpoint SDK."""
+
+import logging
+
+LOGGER_NAME = "fixpoint"
+
+logger = logging.getLogger(LOGGER_NAME)


### PR DESCRIPTION
If you are streaming back chat completions, then we cannot log the full output until we have streamed everything back from the inference provider. So on the frontend, if you try to access the `FixpointChatCompletionStream.output_log` before iterating over the chat completion chunks, the output log will be set to `None`. That's fine, but we log a warning.

After you have iterated over all chunks, we record the output log in the Fixpoint API and the `FixpointChatCompletionStream.output_log` becomes set.