### PR TITLE
Minor version bump due to new `.completions` property

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fixpoint_sdk"
-version = "0.2.1"
+version = "0.3.0"
 
 authors = [
 { name="Jakub Cichon", email="jakub@fixpoint.co" },


### PR DESCRIPTION
Bump the minor version because we added a new
`FixpointChatCompletionStream.completions` property.