### PR TITLE
Fix type-checking and make adjustments to the exposed API

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -1,9 +1,7 @@
+# pylint: disable=unused-variable
+
 """An example using the basics of the Fixpoint SDK."""
 
-# pylint: disable=unused-variable
-from fixpoint_sdk.client import ChatRouterClient
-from fixpoint_sdk.openapi.gen import openapi_client
-from fixpoint_sdk.openapi.gen.openapi_client.rest import ApiException
 from fixpoint_sdk import FixpointClient, ThumbsReaction
 
 
@@ -20,11 +18,11 @@ def main() -> None:
     # associate with the request. The user will be automatically passed through
     # to OpenAI's API.
     resp1 = client.chat.completions.create(
-        model="gpt-3.5-turbo-0125",
         messages=[
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "What are you?"},
         ],
+        model="gpt-3.5-turbo-0125",
         user="some-user-id",
     )
     openai_response = resp1.completion
@@ -35,11 +33,11 @@ def main() -> None:
     # (e.g. a multi-step chain of prompts), you can pass in a trace_id to
     # associate them together.
     resp2 = client.chat.completions.create(
-        model="gpt-3.5-turbo-0125",
         messages=[
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "What are you?"},
         ],
+        model="gpt-3.5-turbo-0125",
         trace_id="some-trace-id",
     )
 
@@ -50,8 +48,6 @@ def main() -> None:
     # If you do not specify a mode, we default to "prod".
     for env_mode in ["test", "staging", "prod"]:
         client.chat.completions.create(
-            model="gpt-3.5-turbo-0125",
-            mode=env_mode,
             messages=[
                 {
                     "role": "system",
@@ -59,6 +55,8 @@ def main() -> None:
                 },
                 {"role": "user", "content": "What are you?"},
             ],
+            model="gpt-3.5-turbo-0125",
+            mode=env_mode,
         )
 
     # Record user feedback. One user giving a thumbs up to a log, the other giving a thumbs down.
@@ -91,58 +89,6 @@ def main() -> None:
             }
         }
     )
-
-    # Define routing configuration
-    routing_config = openapi_client.V1CreateRoutingConfigRequest(
-        id="123",
-        fallback_strategy=openapi_client.V1FallbackStrategy.FALLBACK_STRATEGY_NEXT,
-        terminal_state=openapi_client.V1TerminalState.TERMINAL_STATE_ERROR,
-        models=[
-            openapi_client.V1Model(
-                provider="openai",
-                name="gpt-3.5-turbo-0125",
-                spend_cap=openapi_client.V1SpendCap(
-                    amount="0.0001",
-                    currency="USD",
-                    reset_interval=openapi_client.V1ResetInterval.RESET_INTERVAL_MONTHLY,
-                ),
-            ),
-            openapi_client.V1Model(
-                provider="openai",
-                name="gpt-3.5-turbo-0301",
-                spend_cap=openapi_client.V1SpendCap(
-                    amount="0.0001",
-                    currency="USD",
-                    reset_interval=openapi_client.V1ResetInterval.RESET_INTERVAL_MONTHLY,
-                ),
-            ),
-        ],
-        description="This is a test routing config.",
-    )
-
-    try:
-        api_response = client.fixpoint.proxy_client.llm_proxy_create_routing_config(
-            routing_config
-        )
-    except ApiException as e:
-        print(
-            f"Exception when calling LLMProxyApi->llm_proxy_create_routing_config: {e}\n"
-        )
-
-    client_with_router = ChatRouterClient()
-
-    try:
-        api_response = client_with_router.chat.completions.create(
-            mode="test",
-            user="some-user-id",
-            trace_id="some-trace-id",
-            messages=[
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": "What are you?"},
-            ],
-        )
-    except ApiException as e:
-        print(f"Exception when calling ChatCompletionsApi->create: {e}\n")
 
 
 if __name__ == "__main__":

--- a/examples/router.py
+++ b/examples/router.py
@@ -1,0 +1,73 @@
+# pylint: disable=unused-variable
+
+"""Examples using the inference router.
+
+The inference router can send LLM inference requests to different models based
+on configurable rules.
+"""
+
+
+from fixpoint_sdk import openapi_client, ChatRouterClient
+from fixpoint_sdk.openapi.exceptions import ApiException
+
+
+def main() -> None:
+    """Example using inference router."""
+    client = ChatRouterClient()
+
+    # Define routing configuration
+    routing_config_req = openapi_client.V1CreateRoutingConfigRequest(
+        fallback_strategy=openapi_client.V1FallbackStrategy.FALLBACK_STRATEGY_NEXT,
+        terminal_state=openapi_client.V1TerminalState.TERMINAL_STATE_ERROR,
+        models=[
+            openapi_client.V1Model(
+                provider="openai",
+                name="gpt-3.5-turbo-0125",
+                spend_cap=openapi_client.V1SpendCap(
+                    amount="0.0001",
+                    currency="USD",
+                    reset_interval=openapi_client.V1ResetInterval.RESET_INTERVAL_MONTHLY,
+                ),
+            ),
+            openapi_client.V1Model(
+                provider="openai",
+                name="gpt-3.5-turbo-0301",
+                spend_cap=openapi_client.V1SpendCap(
+                    amount="0.0001",
+                    currency="USD",
+                    reset_interval=openapi_client.V1ResetInterval.RESET_INTERVAL_MONTHLY,
+                ),
+            ),
+        ],
+        description="This is a test routing config.",
+    )
+
+    try:
+        routing_config = client.fixpoint.proxy_client.llm_proxy_create_routing_config(
+            routing_config_req
+        )
+    except ApiException as e:
+        print(
+            f"Exception when calling LLMProxyApi->llm_proxy_create_routing_config: {e}\n"
+        )
+    print(f"Routing config created. ID = {routing_config.id}")
+
+    try:
+        completion = client.chat.completions.create(
+            mode="test",
+            user="some-user-id",
+            trace_id="some-trace-id",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "What are you?"},
+            ],
+        )
+    except ApiException as e:
+        print(f"Exception when calling ChatCompletionsApi->create: {e}\n")
+
+    print("Received chat completion inference response.")
+    print(completion.completion)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -37,7 +37,7 @@ def main() -> None:
     #
     # Pylint is getting this wrong
     # pylint: disable=not-an-iterable
-    for chunk in resp.completions:
+    for chunk in resp.completion:
         content = chunk.choices[0].delta.content
         if content:
             text_contents.append(content)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-exclude = (examples/|venv/|src/fixpoint_sdk/openapi)
+exclude = (venv/|src/fixpoint_sdk/openapi/gen)
 # Start off with these
 warn_unused_configs = True
 warn_redundant_casts = True
@@ -24,10 +24,12 @@ disallow_incomplete_defs = True
 disallow_untyped_defs = True
 
 # This one isn't too hard to get passing, but return on investment is lower
-no_implicit_reexport = True
+no_implicit_reexport = False
 
 # This one can be tricky to get passing if you use a lot of untyped libraries
 warn_return_any = True
 
 # It's ok if our third party imports are not typed
 ignore_missing_imports = True
+
+plugins = pydantic.mypy

--- a/src/fixpoint_sdk/__init__.py
+++ b/src/fixpoint_sdk/__init__.py
@@ -1,7 +1,8 @@
 """The Fixpoint SDK provides a Python client for the Fixpoint API."""
 
-from .client import FixpointClient
+from .client import FixpointClient, ChatRouterClient
 from .completions import FixpointChatCompletion, FixpointChatCompletionStream
+from .openapi.gen import openapi_client
 from . import types
 from .types import ThumbsReaction, ModeType
 from . import compat
@@ -9,8 +10,10 @@ from .lib.logging import logger, LOGGER_NAME
 
 __all__ = [
     "FixpointClient",
+    "ChatRouterClient",
     "ThumbsReaction",
     "ModeType",
+    "openapi_client",
     "types",
     "compat",
     "FixpointChatCompletion",

--- a/src/fixpoint_sdk/client.py
+++ b/src/fixpoint_sdk/client.py
@@ -4,9 +4,9 @@ import typing
 
 from openai import OpenAI
 
-from fixpoint_sdk.openapi.gen.openapi_client.configuration import Configuration
-from fixpoint_sdk.openapi.gen.openapi_client.api_client import ApiClient
-from fixpoint_sdk.openapi.gen.openapi_client.api.llm_proxy_api import LLMProxyApi
+from .openapi.gen.openapi_client.configuration import Configuration
+from .openapi.gen.openapi_client.api_client import ApiClient
+from .openapi.gen.openapi_client.api.llm_proxy_api import LLMProxyApi
 
 from .lib.env import get_fixpoint_api_key, get_api_base_url
 from .lib.requests import Requester
@@ -14,82 +14,99 @@ from . import types
 from .completions import Chat, ChatWithRouter
 
 
-class ChatRouterClient:
+class _FixpointClientBase:
+    def __init__(
+        self,
+        *,
+        fixpoint_api_key: typing.Optional[str] = None,
+        openai_api_key: typing.Optional[str] = None,
+        api_base_url: typing.Optional[str] = None,
+        **kwargs: typing.Any,
+    ):
+        # Check that the environment variable FIXPOINT_API_KEY is set
+        _api_key = get_fixpoint_api_key(fixpoint_api_key)
+
+        self._api_key = _api_key
+        self._requester = Requester(self._api_key, get_api_base_url(api_base_url))
+        if openai_api_key:
+            kwargs = dict(kwargs, api_key=openai_api_key)
+        self.fixpoint = _Fixpoint(self._requester)
+
+
+class ChatRouterClient(_FixpointClientBase):
     """The ChatRouterClient lets you interact with the Fixpoint API and the OpenAI API."""
 
     def __init__(
         self,
-        *args: typing.Any,
+        *,
         fixpoint_api_key: typing.Optional[str] = None,
         openai_api_key: typing.Optional[str] = None,
         api_base_url: typing.Optional[str] = None,
         **kwargs: typing.Any,
     ):
-        # Check that the environment variable FIXPOINT_API_KEY is set
-        _api_key = get_fixpoint_api_key(fixpoint_api_key)
+        super().__init__(
+            fixpoint_api_key=fixpoint_api_key,
+            openai_api_key=openai_api_key,
+            api_base_url=api_base_url,
+            **kwargs,
+        )
+        client = OpenAI(**kwargs)
+        self.chat = ChatWithRouter(self._requester, client)
 
-        self._api_key = _api_key
-        self._requester = Requester(self._api_key, get_api_base_url(api_base_url))
-        if openai_api_key:
-            kwargs = dict(kwargs, api_key=openai_api_key)
-        self.client = OpenAI(*args, **kwargs)
-        self.chat = ChatWithRouter(self._requester, self.client)
 
-
-class FixpointClient:
+class FixpointClient(_FixpointClientBase):
     """The FixpointClient lets you interact with the Fixpoint API."""
 
     def __init__(
         self,
-        *args: typing.Any,
+        *,
         fixpoint_api_key: typing.Optional[str] = None,
         openai_api_key: typing.Optional[str] = None,
         api_base_url: typing.Optional[str] = None,
         **kwargs: typing.Any,
     ):
-        # Check that the environment variable FIXPOINT_API_KEY is set
-        _api_key = get_fixpoint_api_key(fixpoint_api_key)
+        super().__init__(
+            fixpoint_api_key=fixpoint_api_key,
+            openai_api_key=openai_api_key,
+            api_base_url=api_base_url,
+            **kwargs,
+        )
+        client = OpenAI(**kwargs)
+        self.chat = Chat(self._requester, client)
 
-        self._api_key = _api_key
-        self._requester = Requester(self._api_key, get_api_base_url(api_base_url))
-        if openai_api_key:
-            kwargs = dict(kwargs, api_key=openai_api_key)
-        self.client = OpenAI(*args, **kwargs)
-        self.chat = Chat(self._requester, self.client)
-        self.fixpoint = self._Fixpoint(self._requester)
 
-    class _Fixpoint:
+class _Fixpoint:
+    def __init__(self, requester: Requester):
+        self.user_feedback = self._UserFeedback(requester)
+        self.attributes = self._Attributes(requester)
+
+        configuration = Configuration(
+            host=get_api_base_url(requester.base_url),
+        )
+
+        api_client = ApiClient(
+            configuration,
+            header_name="Authorization",
+            header_value=f"Bearer {requester.api_key}",
+        )
+        self.proxy_client = LLMProxyApi(api_client)
+
+    class _UserFeedback:
         def __init__(self, requester: Requester):
-            self.user_feedback = self._UserFeedback(requester)
-            self.attributes = self._Attributes(requester)
+            self._requester = requester
 
-            configuration = Configuration(
-                host=get_api_base_url(requester.base_url),
-            )
+        def create(
+            self, request: types.CreateUserFeedbackRequest
+        ) -> types.CreateUserFeedbackResponse:
+            """Attach user feedback to an LLM log."""
+            return self._requester.create_user_feedback(request)
 
-            api_client = ApiClient(
-                configuration,
-                header_name="Authorization",
-                header_value=f"Bearer {requester.api_key}",
-            )
-            self.proxy_client = LLMProxyApi(api_client)
+    class _Attributes:
+        def __init__(self, requester: Requester):
+            self._requester = requester
 
-        class _UserFeedback:
-            def __init__(self, requester: Requester):
-                self._requester = requester
-
-            def create(
-                self, request: types.CreateUserFeedbackRequest
-            ) -> types.CreateUserFeedbackResponse:
-                """Attach user feedback to an LLM log."""
-                return self._requester.create_user_feedback(request)
-
-        class _Attributes:
-            def __init__(self, requester: Requester):
-                self._requester = requester
-
-            def create(
-                self, request: types.CreateLogAttributeRequest
-            ) -> types.LogAttribute:
-                """Attach a log attribute to an LLM log."""
-                return self._requester.create_attribute(request)
+        def create(
+            self, request: types.CreateLogAttributeRequest
+        ) -> types.LogAttribute:
+            """Attach a log attribute to an LLM log."""
+            return self._requester.create_attribute(request)

--- a/src/fixpoint_sdk/openapi/__init__.py
+++ b/src/fixpoint_sdk/openapi/__init__.py
@@ -1,0 +1,4 @@
+from .gen import openapi_client
+from .gen.openapi_client import exceptions
+
+__all__ = ["openapi_client", "exceptions"]

--- a/src/fixpoint_sdk/openapi/exceptions.py
+++ b/src/fixpoint_sdk/openapi/exceptions.py
@@ -1,0 +1,3 @@
+from .gen.openapi_client.exceptions import ApiException
+
+__all__ = ["ApiException"]


### PR DESCRIPTION
There were some problems with type-checking the `fixpoint_sdk`:

1. Pydantic expected "camelCase" but can also work with "snake_case". To fix this, use the Pydantic plugin for mypy.
2. Fix type overloading problems with streaming mode on versus off.
3. Make sure that you can pass arbitrary extra variables to the `FixpointClient.chat.completions.create` method.

Also expose a few of the generated OpenAPI client modules and values from either `fixpoint_sdk` or `fixpoint_sdk.openapi` instead of `fixpoint_sdk.openapi.gen`.