### PR TITLE
Make the router example more extensive

### DIFF
--- a/examples/router.py
+++ b/examples/router.py
@@ -6,16 +6,48 @@ The inference router can send LLM inference requests to different models based
 on configurable rules.
 """
 
+import os
 
 from fixpoint_sdk import openapi_client, ChatRouterClient
 from fixpoint_sdk.openapi.exceptions import ApiException
 
 
-def main() -> None:
+def main(skip_creating_config: bool) -> None:
     """Example using inference router."""
     client = ChatRouterClient()
+    if not skip_creating_config:
+        # use this config to cap spend on all models
+        # create_routing_config_all_capped(client)
 
-    # Define routing configuration
+        # Use this config to let the last model run forever after previous model
+        # caps were reached.
+        create_routing_config_last_uncapped(client)
+    try:
+        completion = client.chat.completions.create(
+            mode="test",
+            user="some-user-id",
+            trace_id="some-trace-id",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "What are you?"},
+            ],
+        )
+    except ApiException as e:
+        print(f"Exception when calling ChatCompletionsApi->create: {e}\n")
+
+    print("Received chat completion inference response.")
+    print(completion.completion)
+
+
+def create_routing_config_all_capped(client: ChatRouterClient) -> None:
+    """Create a routing config where all models are capped.
+
+    Define routing configuration This example:
+
+    1. Tries to use gpt-3.5-turbo-0125 until it has spent $0.0001.
+    2. After that, it will try to use gpt-3.5-turbo-0301, until spending $0.0001.
+    3. After that, it rejects requests.
+    """
     routing_config_req = openapi_client.V1CreateRoutingConfigRequest(
         fallback_strategy=openapi_client.V1FallbackStrategy.FALLBACK_STRATEGY_NEXT,
         terminal_state=openapi_client.V1TerminalState.TERMINAL_STATE_ERROR,
@@ -52,22 +84,46 @@ def main() -> None:
         )
     print(f"Routing config created. ID = {routing_config.id}")
 
-    try:
-        completion = client.chat.completions.create(
-            mode="test",
-            user="some-user-id",
-            trace_id="some-trace-id",
-            messages=[
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": "What are you?"},
-            ],
-        )
-    except ApiException as e:
-        print(f"Exception when calling ChatCompletionsApi->create: {e}\n")
 
-    print("Received chat completion inference response.")
-    print(completion.completion)
+def create_routing_config_last_uncapped(client: ChatRouterClient) -> None:
+    """Create a routing config where the last model is uncapped.
+
+    Define routing configuration This example:
+
+    1. Tries to use gpt-3.5-turbo-0125 until it has spent $0.0001.
+    2. After that, it will use gpt-3.5-turbo-0301, without a spending cap.
+    """
+    routing_config_req = openapi_client.V1CreateRoutingConfigRequest(
+        fallback_strategy=openapi_client.V1FallbackStrategy.FALLBACK_STRATEGY_NEXT,
+        terminal_state=openapi_client.V1TerminalState.TERMINAL_STATE_IGNORE_CAP,
+        models=[
+            openapi_client.V1Model(
+                provider="openai",
+                name="gpt-3.5-turbo-0125",
+                spend_cap=openapi_client.V1SpendCap(
+                    amount="0.0001",
+                    currency="USD",
+                    reset_interval=openapi_client.V1ResetInterval.RESET_INTERVAL_MONTHLY,
+                ),
+            ),
+            openapi_client.V1Model(
+                provider="openai",
+                name="gpt-3.5-turbo-0301",
+            ),
+        ],
+        description="This is a test routing config.",
+    )
+
+    try:
+        routing_config = client.fixpoint.proxy_client.llm_proxy_create_routing_config(
+            routing_config_req
+        )
+        print(f"Routing config created. ID = {routing_config.id}")
+    except ApiException as e:
+        print(
+            f"Exception when calling LLMProxyApi->llm_proxy_create_routing_config: {e}\n"
+        )
 
 
 if __name__ == "__main__":
-    main()
+    main(os.environ.get("SKIP_CREATING_CONFIG", "false").lower() == "true")

--- a/examples/router.py
+++ b/examples/router.py
@@ -82,6 +82,7 @@ def create_routing_config_all_capped(client: ChatRouterClient) -> None:
         print(
             f"Exception when calling LLMProxyApi->llm_proxy_create_routing_config: {e}\n"
         )
+        raise
     print(f"Routing config created. ID = {routing_config.id}")
 
 

--- a/src/fixpoint_sdk/__init__.py
+++ b/src/fixpoint_sdk/__init__.py
@@ -8,6 +8,8 @@ from .types import ThumbsReaction, ModeType
 from . import compat
 from .lib.logging import logger, LOGGER_NAME
 
+from .lib.exc import FixpointException, InitException, ApiException
+
 __all__ = [
     "FixpointClient",
     "ChatRouterClient",
@@ -20,4 +22,7 @@ __all__ = [
     "FixpointChatCompletionStream",
     "logger",
     "LOGGER_NAME",
+    "FixpointException",
+    "InitException",
+    "ApiException",
 ]

--- a/src/fixpoint_sdk/lib/exc.py
+++ b/src/fixpoint_sdk/lib/exc.py
@@ -1,5 +1,18 @@
 """Exceptions for the Fixpoint SDK."""
 
 
-class InitException(Exception):
+class FixpointException(Exception):
+    """The base Fixpoint SDK exception."""
+
+
+class InitException(FixpointException):
     """An exception raised when the Fixpoint client fails to initialize."""
+
+
+class ApiException(FixpointException):
+    """An exception raised when the Fixpoint API returns an error."""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"API error: {status_code} {message}")

--- a/src/fixpoint_sdk/lib/requests.py
+++ b/src/fixpoint_sdk/lib/requests.py
@@ -7,6 +7,7 @@ from openai.types.chat import ChatCompletion
 
 from .debugging import debug_log_function_io
 from .. import types
+from ..lib import exc
 
 DEFAULT_TIMEOUT_S = 60
 
@@ -206,7 +207,10 @@ class Requester:
         resp = requests.post(
             url, headers=headers, json=req_or_resp_obj, timeout=self.timeout_s
         )
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as e:
+            raise exc.ApiException(e.response.status_code, e.response.text) from e
         if self._on_api_call:
             self._on_api_call(url, req_or_resp_obj, resp.json())
         return resp


### PR DESCRIPTION
Make the router example more extensive. It now shows an example using a config that caps all model spend, and another that has an uncapped fallback with unlimited spend.