### PR TITLE
Make some args required for routed chat completions

### DIFF
--- a/src/fixpoint_sdk/lib/requests.py
+++ b/src/fixpoint_sdk/lib/requests.py
@@ -41,16 +41,17 @@ class Requester:
     @debug_log_function_io
     def create_openai_routed_log(
         self,
-        request: types.OpenAILLMInputLog,
+        request: types.openai.RoutedCreateChatCompletionRequest,
         trace_id: typing.Optional[str] = None,
         mode: types.ModeType = types.ModeType.MODE_UNSPECIFIED,
     ) -> types.ChatCompletion:
         """Create routed input log for an LLM inference request."""
         url = f"{self.base_url}/v1/router"
+        req_dict = request.to_dict()
         input_log_req = types.CreateLLMRoutingRequest(
-            messages=request["messages"],
-            user_id=request.get("user", None),
-            temperature=request.get("temperature", None),
+            messages=request.messages,
+            user_id=req_dict.get("user", None),
+            temperature=req_dict.get("temperature", None),
             trace_id=trace_id,
             mode=mode,
         )

--- a/src/fixpoint_sdk/types/__init__.py
+++ b/src/fixpoint_sdk/types/__init__.py
@@ -5,6 +5,11 @@ import enum
 from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 from openai.types.chat import ChatCompletionMessageParam
 
+from . import openai
+from ._utils import to_dict_without_not_given, is_not_given, get_value_or_none
+
+__all__ = ["openai", "is_not_given", "get_value_or_none"]
+
 
 class ThumbsReaction(enum.Enum):
     """The specific user feedback reaction."""
@@ -84,7 +89,7 @@ class CreateLLMRoutingRequest:
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert this request to a dictionary."""
-        d = asdict(self)
+        d = to_dict_without_not_given(self)
         if self.mode is not None:
             d["mode"] = self.mode.value
         return d
@@ -103,7 +108,7 @@ class CreateLLMInputLogRequest:
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert this request to a dictionary."""
-        d = asdict(self)
+        d = to_dict_without_not_given(self)
         # convert this to a JSON-serializable type
         if self.mode is not None:
             d["mode"] = self.mode.value
@@ -111,7 +116,7 @@ class CreateLLMInputLogRequest:
 
 
 class OpenAILLMInputLog(TypedDict, total=False):
-    """An input log with attributes from OpenAI response.
+    """An input log with attributes from OpenAI request.
 
     This input log has some attributes that come directly from an OpenAI
     response. Some of the field names are slightly off from what our Fixpoint

--- a/src/fixpoint_sdk/types/_utils.py
+++ b/src/fixpoint_sdk/types/_utils.py
@@ -1,0 +1,31 @@
+"""Utilities for working with types."""
+
+from dataclasses import fields
+from typing import cast, Any, Dict, Optional, TypeVar
+
+from openai._types import NOT_GIVEN, NotGiven
+
+
+T = TypeVar("T")
+
+
+def to_dict_without_not_given(obj: Any) -> Dict[str, Any]:
+    """Convert a dataclass to a dictionary, excluding fields with the value NOT_GIVEN"""
+    result = {}
+    for field in fields(obj.__class__):
+        value = getattr(obj, field.name)
+        if value != NOT_GIVEN and not isinstance(value, NotGiven):
+            result[field.name] = value
+    return result
+
+
+def get_value_or_none(value: Optional[T]) -> Optional[T]:
+    """If a value is given, return it. Otherwise return None"""
+    if is_not_given(value):
+        return cast(T, value)
+    return None
+
+
+def is_not_given(value: Any) -> bool:
+    """Check if a value's type is not given, versus being defined or set to None"""
+    return value == NOT_GIVEN and isinstance(value, NotGiven)

--- a/src/fixpoint_sdk/types/openai.py
+++ b/src/fixpoint_sdk/types/openai.py
@@ -1,0 +1,118 @@
+"""Types for interfacing with the OpenAI API and SDK"""
+
+from typing import Any, Dict, List, Literal, Optional, Union
+from dataclasses import dataclass
+
+import httpx
+
+from openai._types import NOT_GIVEN, NotGiven, Body, Query, Headers
+from openai.types.chat import (
+    completion_create_params,
+    ChatCompletionToolParam,
+    ChatCompletionToolChoiceOptionParam,
+)
+from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
+
+from ._utils import to_dict_without_not_given
+
+
+Model = Union[
+    str,
+    Literal[
+        "gpt-4-1106-preview",
+        "gpt-4-vision-preview",
+        "gpt-4",
+        "gpt-4-0314",
+        "gpt-4-0613",
+        "gpt-4-32k",
+        "gpt-4-32k-0314",
+        "gpt-4-32k-0613",
+        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-16k",
+        "gpt-3.5-turbo-0301",
+        "gpt-3.5-turbo-0613",
+        "gpt-3.5-turbo-1106",
+        "gpt-3.5-turbo-16k-0613",
+    ],
+]
+
+
+@dataclass
+class CreateChatCompletionRequest:
+    """A normal chat completion create request"""
+
+    messages: List[ChatCompletionMessageParam]
+    model: Model
+    frequency_penalty: Union[Optional[float], NotGiven] = NOT_GIVEN
+    function_call: Union[completion_create_params.FunctionCall, NotGiven] = NOT_GIVEN
+    functions: Union[List[completion_create_params.Function], NotGiven] = NOT_GIVEN
+    logit_bias: Union[Optional[Dict[str, int]], NotGiven] = NOT_GIVEN
+    logprobs: Union[Optional[bool], NotGiven] = NOT_GIVEN
+    max_tokens: Union[Optional[int], NotGiven] = NOT_GIVEN
+    n: Union[Optional[int], NotGiven] = NOT_GIVEN
+    presence_penalty: Union[Optional[float], NotGiven] = NOT_GIVEN
+    response_format: Union[completion_create_params.ResponseFormat, NotGiven] = (
+        NOT_GIVEN
+    )
+    seed: Union[Optional[int], NotGiven] = NOT_GIVEN
+    stop: Union[Union[Optional[str], List[str]], NotGiven] = NOT_GIVEN
+    stream: Union[Optional[Literal[False]], Literal[True], NotGiven] = NOT_GIVEN
+    temperature: Union[Optional[float], NotGiven] = NOT_GIVEN
+    tool_choice: Union[ChatCompletionToolChoiceOptionParam, NotGiven] = NOT_GIVEN
+    tools: Union[List[ChatCompletionToolParam], NotGiven] = NOT_GIVEN
+    top_logprobs: Union[Optional[int], NotGiven] = NOT_GIVEN
+    top_p: Union[Optional[float], NotGiven] = NOT_GIVEN
+    user: Union[str, NotGiven] = NOT_GIVEN
+
+    # Use the following arguments if you need to pass additional parameters
+    # to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the
+    # client or passed to this method.
+    extra_headers: Union[Headers, None] = None
+    extra_query: Union[Query, None] = None
+    extra_body: Union[Body, None] = None
+    timeout: Union[float, httpx.Timeout, None, NotGiven] = NOT_GIVEN
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a dict, removing fields that were never set."""
+        return to_dict_without_not_given(self)
+
+
+@dataclass
+class RoutedCreateChatCompletionRequest:
+    """A chat completion create request for a model-router completion"""
+
+    messages: List[ChatCompletionMessageParam]
+    frequency_penalty: Union[Optional[float], NotGiven] = NOT_GIVEN
+    function_call: Union[completion_create_params.FunctionCall, NotGiven] = NOT_GIVEN
+    functions: Union[List[completion_create_params.Function], NotGiven] = NOT_GIVEN
+    logit_bias: Union[Optional[Dict[str, int]], NotGiven] = NOT_GIVEN
+    logprobs: Union[Optional[bool], NotGiven] = NOT_GIVEN
+    max_tokens: Union[Optional[int], NotGiven] = NOT_GIVEN
+    n: Union[Optional[int], NotGiven] = NOT_GIVEN
+    presence_penalty: Union[Optional[float], NotGiven] = NOT_GIVEN
+    response_format: Union[completion_create_params.ResponseFormat, NotGiven] = (
+        NOT_GIVEN
+    )
+    seed: Union[Optional[int], NotGiven] = NOT_GIVEN
+    stop: Union[Union[Optional[str], List[str]], NotGiven] = NOT_GIVEN
+    stream: Union[Optional[Literal[False]], Literal[True], NotGiven] = NOT_GIVEN
+    temperature: Union[Optional[float], NotGiven] = NOT_GIVEN
+    tool_choice: Union[ChatCompletionToolChoiceOptionParam, NotGiven] = NOT_GIVEN
+    tools: Union[List[ChatCompletionToolParam], NotGiven] = NOT_GIVEN
+    top_logprobs: Union[Optional[int], NotGiven] = NOT_GIVEN
+    top_p: Union[Optional[float], NotGiven] = NOT_GIVEN
+    user: Union[str, NotGiven] = NOT_GIVEN
+
+    # Use the following arguments if you need to pass additional parameters
+    # to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the
+    # client or passed to this method.
+    extra_headers: Union[Headers, None] = None
+    extra_query: Union[Query, None] = None
+    extra_body: Union[Body, None] = None
+    timeout: Union[float, httpx.Timeout, None, NotGiven] = NOT_GIVEN
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a dict, removing fields that were never set."""
+        return to_dict_without_not_given(self)

--- a/tests/types/test_openai.py
+++ b/tests/types/test_openai.py
@@ -1,0 +1,49 @@
+# pylint: disable=missing-function-docstring, missing-class-docstring, missing-module-docstring
+
+from typing import Any, Dict
+
+from fixpoint_sdk.types import openai
+
+
+def test_to_dict() -> None:
+    request = openai.CreateChatCompletionRequest(
+        messages=[{"role": "user", "content": "Hello!"}], model="gpt-3.5-turbo"
+    )
+    expected: Dict[str, Any] = {
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "model": "gpt-3.5-turbo",
+        "extra_body": None,
+        "extra_query": None,
+        "extra_headers": None,
+    }
+    assert request.to_dict() == expected
+
+    request = openai.CreateChatCompletionRequest(
+        messages=[{"role": "user", "content": "Hello!"}],
+        model="gpt-3.5-turbo",
+        frequency_penalty=0.5,
+    )
+    expected = {
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "model": "gpt-3.5-turbo",
+        "frequency_penalty": 0.5,
+        "extra_body": None,
+        "extra_query": None,
+        "extra_headers": None,
+    }
+    assert request.to_dict() == expected
+
+    request = openai.CreateChatCompletionRequest(
+        messages=[{"role": "user", "content": "Hello!"}],
+        model="gpt-3.5-turbo",
+        frequency_penalty=None,
+    )
+    expected = {
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "model": "gpt-3.5-turbo",
+        "frequency_penalty": None,
+        "extra_body": None,
+        "extra_query": None,
+        "extra_headers": None,
+    }
+    assert request.to_dict() == expected


### PR DESCRIPTION
Change the interface for the `RoutedCompletions.create` method, requiring us to pass in `messages` and preventing us from passing in `model`.

Under the hood, make typing changes to make this explicit requirement clearer.