### PR TITLE
Add tests to check the calls to LLM input/output logging

### DIFF
--- a/src/fixpoint_sdk/_mock_completions.py
+++ b/src/fixpoint_sdk/_mock_completions.py
@@ -1,0 +1,23 @@
+"""Mocks for the completions module"""
+
+from typing import Callable
+from unittest.mock import Mock
+
+from openai.types.chat import ChatCompletion
+
+from . import types
+
+ChatCompletionFn = Callable[[types.openai.CreateChatCompletionRequest], ChatCompletion]
+
+
+class MockChatCompletion:
+    """A mocked ChatCompletion class"""
+
+    create_completion: ChatCompletionFn
+
+    def __init__(self) -> None:
+        self.create_completion = Mock()
+
+    def set_return_value(self, retval: ChatCompletion) -> None:
+        """Set the return value of the create_completion function."""
+        self.create_completion.return_value = retval  # type: ignore

--- a/src/fixpoint_sdk/client.py
+++ b/src/fixpoint_sdk/client.py
@@ -1,5 +1,6 @@
 """Defines the Fixpoint client, which is the main interface for the SDK."""
 
+from dataclasses import dataclass
 import typing
 
 from openai import OpenAI
@@ -11,7 +12,13 @@ from .openapi.gen.openapi_client.api.llm_proxy_api import LLMProxyApi
 from .lib.env import get_fixpoint_api_key, get_api_base_url
 from .lib.requests import Requester
 from . import types
-from .completions import Chat, ChatWithRouter
+from .completions import Chat, ChatWithRouter, _ChatDeps
+
+
+@dataclass
+class _FixpointClientDeps:
+    chat: typing.Optional[_ChatDeps] = None
+    requester: typing.Optional[Requester] = None
 
 
 class _FixpointClientBase:
@@ -21,13 +28,17 @@ class _FixpointClientBase:
         fixpoint_api_key: typing.Optional[str] = None,
         openai_api_key: typing.Optional[str] = None,
         api_base_url: typing.Optional[str] = None,
+        _deps: typing.Optional[_FixpointClientDeps] = None,
         **kwargs: typing.Any,
     ):
         # Check that the environment variable FIXPOINT_API_KEY is set
         _api_key = get_fixpoint_api_key(fixpoint_api_key)
 
         self._api_key = _api_key
-        self._requester = Requester(self._api_key, get_api_base_url(api_base_url))
+        if _deps and _deps.requester:
+            self._requester = _deps.requester
+        else:
+            self._requester = Requester(self._api_key, get_api_base_url(api_base_url))
         if openai_api_key:
             kwargs = dict(kwargs, api_key=openai_api_key)
         self.fixpoint = _Fixpoint(self._requester)
@@ -63,16 +74,21 @@ class FixpointClient(_FixpointClientBase):
         fixpoint_api_key: typing.Optional[str] = None,
         openai_api_key: typing.Optional[str] = None,
         api_base_url: typing.Optional[str] = None,
+        _deps: typing.Optional[_FixpointClientDeps] = None,
         **kwargs: typing.Any,
     ):
         super().__init__(
             fixpoint_api_key=fixpoint_api_key,
             openai_api_key=openai_api_key,
             api_base_url=api_base_url,
+            _deps=_deps,
             **kwargs,
         )
         client = OpenAI(api_key=openai_api_key, **kwargs)
-        self.chat = Chat(self._requester, client)
+        chat_deps = None
+        if _deps:
+            chat_deps = _deps.chat
+        self.chat = Chat(self._requester, client, _deps=chat_deps)
 
 
 class _Fixpoint:
@@ -81,7 +97,7 @@ class _Fixpoint:
         self.attributes = self._Attributes(requester)
 
         configuration = Configuration(
-            host=get_api_base_url(requester.base_url),
+            host=get_api_base_url(requester.base_url()),
         )
 
         api_client = ApiClient(

--- a/src/fixpoint_sdk/lib/_mock_requests.py
+++ b/src/fixpoint_sdk/lib/_mock_requests.py
@@ -1,0 +1,25 @@
+"""Module for mocking the requests module"""
+
+from unittest.mock import Mock
+
+from . import requests
+from .. import types
+
+
+class MockRequester:
+    """A mocked Requester class"""
+
+    requester: requests.Requester
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        input_log_retval: types.InputLog,
+        output_log_retval: types.OutputLog,
+    ) -> None:
+        self.requester = Mock(spec=requests.Requester)
+        self.requester.base_url.return_value = base_url
+        self.requester.api_key.return_value = api_key
+        self.requester.create_openai_input_log.return_value = input_log_retval
+        self.requester.create_openai_output_log.return_value = output_log_retval

--- a/src/fixpoint_sdk/lib/requests.py
+++ b/src/fixpoint_sdk/lib/requests.py
@@ -17,8 +17,8 @@ ApiCallback = typing.Callable[[str, typing.Any, typing.Any], None]
 class Requester:
     """Makes requests to the Fixpoint API."""
 
-    api_key: str
-    base_url: str
+    _api_key: str
+    _base_url: str
     timeout_s: int
     _on_api_call: typing.Optional[ApiCallback]
 
@@ -29,14 +29,22 @@ class Requester:
         timeout_s: int = DEFAULT_TIMEOUT_S,
         _on_api_call: typing.Optional[ApiCallback] = None,
     ):
-        self.api_key = api_key
-        self.base_url = base_url
+        self._api_key = api_key
+        self._base_url = base_url
         self.timeout_s = timeout_s
 
-        if self.base_url[-1] == "/":
-            self.base_url = self.base_url[:-1]
+        if self._base_url[-1] == "/":
+            self._base_url = self._base_url[:-1]
 
         self._on_api_call = _on_api_call
+
+    def base_url(self) -> str:
+        """Get the base URL."""
+        return self._base_url
+
+    def api_key(self) -> str:
+        """Get the API key."""
+        return self._api_key
 
     @debug_log_function_io
     def create_openai_routed_log(
@@ -46,7 +54,7 @@ class Requester:
         mode: types.ModeType = types.ModeType.MODE_UNSPECIFIED,
     ) -> types.ChatCompletion:
         """Create routed input log for an LLM inference request."""
-        url = f"{self.base_url}/v1/router"
+        url = f"{self._base_url}/v1/router"
         req_dict = request.to_dict()
         input_log_req = types.CreateLLMRoutingRequest(
             messages=request.messages,
@@ -70,7 +78,7 @@ class Requester:
         mode: types.ModeType = types.ModeType.MODE_UNSPECIFIED,
     ) -> types.InputLog:
         """Create an input log for an LLM inference request."""
-        url = f"{self.base_url}/v1/openai_chats/{model_name}/input_logs"
+        url = f"{self._base_url}/v1/openai_chats/{model_name}/input_logs"
         input_log_req = types.CreateLLMInputLogRequest(
             model_name=model_name,
             messages=request["messages"],
@@ -93,7 +101,7 @@ class Requester:
         mode: types.ModeType = types.ModeType.MODE_UNSPECIFIED,
     ) -> types.OutputLog:
         """Create an output log for an LLM inference response."""
-        url = f"{self.base_url}/v1/openai_chats/{model_name}/output_logs"
+        url = f"{self._base_url}/v1/openai_chats/{model_name}/output_logs"
 
         # If input_log_results doesn't have id then error
         if "name" not in input_log_results:
@@ -137,7 +145,7 @@ class Requester:
         self, request: types.CreateUserFeedbackRequest
     ) -> types.CreateUserFeedbackResponse:
         """Create user feedback on an LLM log."""
-        url = f"{self.base_url}/v1/likes"
+        url = f"{self._base_url}/v1/likes"
 
         if "likes" not in request:
             raise ValueError("request must have a likes")
@@ -175,7 +183,7 @@ class Requester:
         self, request: types.CreateLogAttributeRequest
     ) -> types.LogAttribute:
         """Create a LLM log attribute and attach it to that LLM log."""
-        url = f"{self.base_url}/v1/attributes"
+        url = f"{self._base_url}/v1/attributes"
 
         if "log_attribute" not in request:
             raise ValueError("request must have a log_attribute")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,135 @@
+# pylint: disable=missing-function-docstring, missing-class-docstring, missing-module-docstring
+
+from dataclasses import dataclass
+from typing import List
+
+from openai.types.chat import ChatCompletion, chat_completion
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
+from openai.types.completion_usage import CompletionUsage
+
+from fixpoint_sdk import FixpointClient, types as fixtypes
+from fixpoint_sdk.client import _FixpointClientDeps
+from fixpoint_sdk.completions import _ChatDeps, _CompletionsDeps
+from fixpoint_sdk.lib._mock_requests import MockRequester
+from fixpoint_sdk._mock_completions import MockChatCompletion
+
+
+def test_log_llm_input_output() -> None:
+    messages: List[ChatCompletionMessageParam] = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What are you?"},
+    ]
+    model = "gpt-3.5-turbo"
+    temperature = 0.7
+    user = "dylan-uid"
+    trace_id = "some-trace-id"
+    input_log_retval: fixtypes.InputLog = {
+        "name": "input-log-name",
+        "modelName": model,
+        "sessionName": None,
+        "messages": messages,
+        "temperature": temperature,
+        "createdAt": None,
+        "traceId": "some-trace-id",
+    }
+    output_log_retval: fixtypes.OutputLog = {"name": "output-log-name"}
+    mock_env = new_mock_chat_client(input_log_retval, output_log_retval)
+
+    completion = ChatCompletion(
+        id="chatcmpl-8y9PZoZGSd7SZDXRLqYCB0FbUD2R7",
+        choices=[
+            chat_completion.Choice(
+                finish_reason="stop",
+                index=0,
+                logprobs=None,
+                message=ChatCompletionMessage(
+                    content="I am a computer program designed to assist and provide information to users like yourself. How can I help you today?",  # pylint: disable=line-too-long
+                    role="assistant",
+                    function_call=None,
+                    tool_calls=None,
+                ),
+            )
+        ],
+        created=1709346549,
+        model=model,
+        object="chat.completion",
+        system_fingerprint="fp_2b778c6b35",
+        usage=CompletionUsage(completion_tokens=23, prompt_tokens=21, total_tokens=44),
+    )
+
+    mock_env.mock_completions.set_return_value(completion)
+
+    mock_env.client.chat.completions.create(
+        messages=messages,
+        model=model,
+        temperature=temperature,
+        user=user,
+        trace_id=trace_id,
+        mode=fixtypes.ModeType.MODE_TEST.value,
+    )
+
+    mock_env.mock_completions.create_completion.assert_called_once()  # type: ignore
+
+    # pylint: disable=line-too-long
+    mock_env.mock_requester.requester.create_openai_input_log.assert_called_once_with(  # type: ignore
+        model,
+        {
+            "temperature": temperature,
+            "user": user,
+            "model_name": model,
+            "messages": messages,
+        },
+        trace_id=trace_id,
+        mode=fixtypes.ModeType.MODE_TEST,
+    )
+
+    # pylint: disable=line-too-long
+    mock_env.mock_requester.requester.create_openai_output_log.assert_called_once_with(  # type: ignore
+        model,
+        input_log_retval,
+        completion,
+        trace_id=trace_id,
+        mode=fixtypes.ModeType.MODE_TEST,
+    )
+
+
+@dataclass
+class MockEnv:
+    client: FixpointClient
+    mock_requester: MockRequester
+    mock_completions: MockChatCompletion
+
+
+def new_mock_chat_client(
+    input_log_retval: fixtypes.InputLog, output_log_retval: fixtypes.OutputLog
+) -> MockEnv:
+    base_url = "http://localhost:8000"
+    fixpoint_api_key = "fake-fixpoint-key"
+    mock_requester = MockRequester(
+        base_url=base_url,
+        api_key=fixpoint_api_key,
+        input_log_retval=input_log_retval,
+        output_log_retval=output_log_retval,
+    )
+    mock_chat_completions = MockChatCompletion()
+
+    client = FixpointClient(
+        api_base_url=base_url,
+        fixpoint_api_key=fixpoint_api_key,
+        openai_api_key="fake-openai-key",
+        _deps=_FixpointClientDeps(
+            requester=mock_requester.requester,
+            chat=_ChatDeps(
+                completions=_CompletionsDeps(
+                    create_completion=mock_chat_completions.create_completion,
+                )
+            ),
+        ),
+    )
+
+    return MockEnv(
+        client=client,
+        mock_requester=mock_requester,
+        mock_completions=mock_chat_completions,
+    )


### PR DESCRIPTION
Add tests to check the calls to LLM input and output logging. To do this, we let the user inject dependencies so that:

1. They can control what function is used to create completions. Useful to mock OpenAI so we aren't wasting money.
2. Can control what `Requester` class is used. Useful to replace it with a `unittest.mock.Mock` instance.