### PR TITLE
Add API for directly logging LLM inputs and outputs

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -435,6 +435,7 @@ disable=raw-checker-failed,
         similarities,
         too-many-arguments,
         too-many-instance-attributes,
+        too-many-return-statements
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/examples/direct_logging.py
+++ b/examples/direct_logging.py
@@ -1,0 +1,45 @@
+"""An example calling OpenAI directly
+
+This example demonstrates how to call OpenAI directly and then to log the LLM
+input and output to Fixpoint.
+"""
+
+from typing import List
+
+from openai import OpenAI
+from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
+
+import fixpoint_sdk
+from fixpoint_sdk import FixpointClient
+
+
+def main() -> None:
+    """An example calling OpenAI directly"""
+    openaiclient = OpenAI()
+    client = FixpointClient()
+
+    messages: List[ChatCompletionMessageParam] = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What are you?"},
+    ]
+    user_id = "some-user-id"
+    model: fixpoint_sdk.types.openai.Model = "gpt-3.5-turbo-0125"
+
+    completion = openaiclient.chat.completions.create(
+        messages=messages, model=model, user=user_id
+    )
+
+    input_log, output_log = client.fixpoint.logging.llm.log_input_and_output(
+        messages,
+        model,
+        completion,
+        mode="test",
+        trace_id="some-trace-id",
+        user=user_id,
+    )
+    print(f"Logged LLM input: {input_log['name']}")
+    print(f"Logged LLM output: {output_log['name']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fixpoint_sdk/_logging_api.py
+++ b/src/fixpoint_sdk/_logging_api.py
@@ -1,0 +1,126 @@
+"""A module for logging LLM inferences and application logs to Fixpoint"""
+
+from typing import cast, Any, List, Optional, Tuple, Union
+
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
+
+from .lib.requests import Requester
+from .lib.debugging import dprint
+from . import types
+
+
+class LLMLogging:
+    """A class for logging LLM input and output to Fixpoint"""
+
+    def __init__(self, requester: Requester):
+        self._requester = requester
+
+    def log_input(
+        self,
+        messages: List[ChatCompletionMessageParam],
+        model: types.openai.Model,
+        temperature: Optional[float] = None,
+        user: Optional[str] = None,
+        trace_id: Optional[str] = None,
+        mode: Optional[Union[types.ModeArg, types.ModeType]] = "unspecified",
+        **kwargs: Any,
+    ) -> types.InputLog:
+        """Log the LLM input to Fixpoint"""
+        return log_llm_input(
+            self._requester,
+            messages=messages,
+            model=model,
+            temperature=temperature,
+            user=user,
+            trace_id=trace_id,
+            mode=mode,
+            **kwargs,
+        )
+
+    def log_output(
+        self,
+        model: types.openai.Model,
+        input_log: types.InputLog,
+        completion: ChatCompletion,
+        trace_id: Optional[str] = None,
+        mode: Optional[Union[types.ModeArg, types.ModeType]] = "unspecified",
+    ) -> types.OutputLog:
+        """Log the LLM output to Fixpoint"""
+        return log_llm_output(
+            self._requester, model, input_log, completion, trace_id, mode
+        )
+
+    def log_input_and_output(
+        self,
+        messages: List[ChatCompletionMessageParam],
+        model: types.openai.Model,
+        completion: ChatCompletion,
+        temperature: Optional[float] = None,
+        user: Optional[str] = None,
+        trace_id: Optional[str] = None,
+        mode: Optional[Union[types.ModeArg, types.ModeType]] = "unspecified",
+        **kwargs: Any,
+    ) -> Tuple[types.InputLog, types.OutputLog]:
+        """Log the LLM input and output to Fixpoint"""
+        input_log = self.log_input(
+            messages=messages,
+            model=model,
+            temperature=temperature,
+            user=user,
+            trace_id=trace_id,
+            mode=mode,
+            **kwargs,
+        )
+        output_log = self.log_output(model, input_log, completion, trace_id, mode)
+        return input_log, output_log
+
+
+def log_llm_input(
+    requester: Requester,
+    messages: List[ChatCompletionMessageParam],
+    model: types.openai.Model,
+    temperature: Optional[float] = None,
+    user: Optional[str] = None,
+    trace_id: Optional[str] = None,
+    mode: Optional[Union[types.ModeArg, types.ModeType]] = "unspecified",
+    **kwargs: Any,
+) -> types.InputLog:
+    """Log the LLM input to Fixpoint"""
+    # Deep copy the kwargs to avoid modifying the original
+    req_copy = cast(types.OpenAILLMInputLog, kwargs.copy())
+    req_copy["model"] = model
+    req_copy["messages"] = messages
+    req_copy["user"] = user
+    req_copy["temperature"] = temperature
+    mode_type = types.parse_mode_type(mode)
+
+    # Send HTTP request before calling create
+    input_resp = requester.create_openai_input_log(
+        req_copy["model"],
+        req_copy,
+        trace_id=trace_id,
+        mode=mode_type,
+    )
+    dprint(f'Created an input log: {input_resp["name"]}')
+    return input_resp
+
+
+def log_llm_output(
+    requester: Requester,
+    model: types.openai.Model,
+    input_log: types.InputLog,
+    completion: ChatCompletion,
+    trace_id: Optional[str] = None,
+    mode: Optional[Union[types.ModeArg, types.ModeType]] = "unspecified",
+) -> types.OutputLog:
+    """Log the LLM output to Fixpoint"""
+    output_log = requester.create_openai_output_log(
+        model,
+        input_log,
+        completion,
+        trace_id=trace_id,
+        mode=types.parse_mode_type(mode),
+    )
+    dprint(f"Created an output log: {output_log['name']}")
+    return output_log

--- a/src/fixpoint_sdk/client.py
+++ b/src/fixpoint_sdk/client.py
@@ -13,6 +13,7 @@ from .lib.env import get_fixpoint_api_key, get_api_base_url
 from .lib.requests import Requester
 from . import types
 from .completions import Chat, ChatWithRouter, _ChatDeps
+from ._logging_api import LLMLogging
 
 
 @dataclass
@@ -95,6 +96,7 @@ class _Fixpoint:
     def __init__(self, requester: Requester):
         self.user_feedback = self._UserFeedback(requester)
         self.attributes = self._Attributes(requester)
+        self.logging = self._Logging(LLMLogging(requester))
 
         configuration = Configuration(
             host=get_api_base_url(requester.base_url()),
@@ -106,6 +108,10 @@ class _Fixpoint:
             header_value=f"Bearer {requester.api_key}",
         )
         self.proxy_client = LLMProxyApi(api_client)
+
+    class _Logging:
+        def __init__(self, llm: LLMLogging):
+            self.llm = llm
 
     class _UserFeedback:
         def __init__(self, requester: Requester):

--- a/src/fixpoint_sdk/types/__init__.py
+++ b/src/fixpoint_sdk/types/__init__.py
@@ -57,11 +57,14 @@ ModeArg = Union[
 ]
 
 
-def parse_mode_type(mode: Optional[Union[str, int, object]] = None) -> ModeType:
+def parse_mode_type(
+    mode: Optional[Union[str, int, object, ModeType]] = None
+) -> ModeType:
     """Parse a mode type from a string."""
     if mode is None:
         return ModeType.MODE_UNSPECIFIED
-
+    if isinstance(mode, ModeType):
+        return mode
     if isinstance(mode, int):
         return ModeType(mode)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -77,7 +77,7 @@ def test_log_llm_input_output() -> None:
         {
             "temperature": temperature,
             "user": user,
-            "model_name": model,
+            "model": model,
             "messages": messages,
         },
         trace_id=trace_id,


### PR DESCRIPTION
Support the use case where a user wants to call OpenAI and then take the responses and explicitly log the LLM inputs/outputs with the Fixpoint API.