### PR TITLE
Fix bug with Fixpoint API key on requests

### DIFF
--- a/src/fixpoint_sdk/lib/requests.py
+++ b/src/fixpoint_sdk/lib/requests.py
@@ -211,7 +211,7 @@ class Requester:
     ) -> requests.Response:
         headers = {
             "Accept": "application/json",
-            "Authorization": f"Bearer {self.api_key}",
+            "Authorization": f"Bearer {self.api_key()}",
         }
         resp = requests.post(
             url, headers=headers, json=req_or_resp_obj, timeout=self.timeout_s


### PR DESCRIPTION
I changed the `Requester.api_key` from a property to a method, but missed updating where we referenced the api key when constructing requests. I was trying to set the auth header to the string value of the function, but it should be the string value of the result of the function.